### PR TITLE
Fix Samsung Notes Screen Off Memo permissions on c1s

### DIFF
--- a/prebuilts/extras/system/etc/permissions/signature-permissions-com.samsung.android.app.notes.xml
+++ b/prebuilts/extras/system/etc/permissions/signature-permissions-com.samsung.android.app.notes.xml
@@ -3,5 +3,7 @@
     <signature-permissions package="com.samsung.android.app.notes">
         <permission name="android.permission.MANAGE_ACTIVITY_TASKS"/>
         <permission name="android.permission.MANAGE_ACTIVITY_STACKS"/>
+        <permission name="android.permission.INTERNAL_SYSTEM_WINDOW"/>
+        <permission name="android.permission.DEVICE_POWER"/>
     </signature-permissions>
 </permissions>


### PR DESCRIPTION
## Summary

Grant the two permissions Samsung Notes requires for Screen Off Memo on `c1s`:

- `android.permission.INTERNAL_SYSTEM_WINDOW`
- `android.permission.DEVICE_POWER`

Without `INTERNAL_SYSTEM_WINDOW`, Samsung Notes fails to add its keyguard window (`type 2009`) with a `BadTokenException`. The alternate wake-up path also throws a `SecurityException` when `DEVICE_POWER` is missing.

This uses ArtisanROM's existing Samsung signature-permission mechanism and only extends the existing permission list for `com.samsung.android.app.notes`.

## Testing

Tested locally on:

- Samsung Galaxy Note20 4G (`SM-N980F`, `c1s`)
- ArtisanROM 3.5.1 official
- KernelSU Next 3.3.0

After adding the permissions:

- `INTERNAL_SYSTEM_WINDOW` is granted
- `DEVICE_POWER` is granted
- Screen Off Memo opens from the screen-off S Pen flow
- S Pen input works
- Screen Off Memo exits normally
- the previous `BadTokenException` and `DEVICE_POWER` `SecurityException` no longer occur in the captured logcat

Fixes #368